### PR TITLE
Append new user selected gallery photos, instead of replace

### DIFF
--- a/reducers/gallery_reducer.js
+++ b/reducers/gallery_reducer.js
@@ -172,11 +172,23 @@ export default function (state = INITIAL_STATE, action) {
          * Return the selected photos from the Camera Roll
          */
         case PHOTOS_FROM_GALLERY:
-            // console.log('PHOTOS_FROM_GALLERY', action.payload);
+            // Copy the current stored gallery:
+            let newGallery = state.gallery;
+
+            // Append each user selected photo (but only if it's not already in the stored gallery)
+            action.payload.forEach(
+                function(photo) {
+                    if(!newGallery.find( ({image}) => image.uri === photo.image.uri )) {
+                        newGallery.push(photo);
+                    }
+                }
+            );
+
+            // Store new version of gallery:
             return {
                 ...state,
-                gallery: action.payload,
-                galleryTotalCount: action.payload.length
+                gallery: newGallery,
+                galleryTotalCount: newGallery.length
             };
 
         /**


### PR DESCRIPTION
This addresses Issue #6. 

Currently, if the user has selected & tagged some photos from their phone's gallery, then tries to select more gallery photos, the original set of photos is replaced by the new set & so they lose their original selection & tags. 

I've modified the gallery reducer action to append the newly selected photos to the current set, rather than replacing the current set.