### PR TITLE
fix #4 : clears text field after one tag is selected

### DIFF
--- a/screens/pages/components/LitterBottomSearch.js
+++ b/screens/pages/components/LitterBottomSearch.js
@@ -82,6 +82,8 @@ class LitterBottomSearch extends PureComponent {
         } else {
             console.log('problem@addTag');
         }
+        // clears text filed after one tag is selected
+        this.setState({ text: '' });
     }
 
     /**
@@ -290,6 +292,7 @@ class LitterBottomSearch extends PureComponent {
                         onChangeText={text => this.updateText(text)}
                         selectionColor="black"
                         blurOnSubmit={false}
+                        clearButtonMode="always"
                         value={this.state.text}
                     />
 


### PR DESCRIPTION
I am only clearing the text field not resetting the suggested tags.
As one may type "bottle" and want to select multiple type of bottles , so if we reset suggestions user will have to type again