### PR TITLE
Littercoin progress circle

### DIFF
--- a/reducers/auth_reducer.js
+++ b/reducers/auth_reducer.js
@@ -197,17 +197,20 @@ export default function(state = INITIAL_STATE, action) {
             } else {
                 user = action.payload.userObj;
             }
-            // console.log(JSON.stringify(user, null, '\t'));
             const level = XPLEVEL.findIndex(xp => xp > user.xp);
             const xpRequired = XPLEVEL[level] - user.xp;
-
-            const targetPercentage = (user.xp / XPLEVEL[level]) * 100;
+            const previousTarget = level > 0 ? XPLEVEL[level - 1] : 0;
+            const targetPercentage =
+                ((user.xp - previousTarget) /
+                    (XPLEVEL[level] - previousTarget)) *
+                100;
             user.level = level;
             user.xpRequired = xpRequired;
             user.targetPercentage = targetPercentage;
             user.totalTags = user.total_brands + user.total_tags;
             user.totalLittercoin =
                 (user.littercoin_allowance || 0) + (user.littercoin_owed || 0);
+
             AsyncStorage.setItem('user', JSON.stringify(user));
             return {
                 ...state,

--- a/reducers/auth_reducer.js
+++ b/reducers/auth_reducer.js
@@ -206,6 +206,8 @@ export default function(state = INITIAL_STATE, action) {
             user.xpRequired = xpRequired;
             user.targetPercentage = targetPercentage;
             user.totalTags = user.total_brands + user.total_tags;
+            user.totalLittercoin =
+                (user.littercoin_allowance || 0) + (user.littercoin_owed || 0);
             AsyncStorage.setItem('user', JSON.stringify(user));
             return {
                 ...state,

--- a/screens/camera/CameraScreen.js
+++ b/screens/camera/CameraScreen.js
@@ -37,7 +37,7 @@ const SCREEN_WIDTH = Dimensions.get('window').width;
 class CameraScreen extends React.Component {
     constructor(props) {
         super(props);
-
+        this.locationSubscription;
         this.state = {
             lat: null,
             lon: null,
@@ -69,7 +69,8 @@ class CameraScreen extends React.Component {
 
     componentWillUnmount() {
         // unsubscribe to location services on unmount
-        this.locationSubscription();
+
+        this.locationSubscription && this.locationSubscription();
         this.focusListner();
         this.blurListner();
     }

--- a/screens/components/AnimatedCircle.js
+++ b/screens/components/AnimatedCircle.js
@@ -20,7 +20,8 @@ const AnimatedCircle = ({
     valueStyles,
     max = 100,
     tagline,
-    taglineStyles
+    taglineStyles,
+    isValueDisplayed = true
 }) => {
     const animated = React.useRef(new Animated.Value(0)).current;
     const textAnimated = React.useRef(new Animated.Value(0)).current;
@@ -133,36 +134,38 @@ const AnimatedCircle = ({
                     />
                 </G>
             </Svg>
-            <View
-                style={[
-                    StyleSheet.absoluteFillObject,
-                    {
-                        alignItems: 'center',
-                        justifyContent: 'center'
-                    }
-                ]}>
-                <AnimatedTextInput
-                    ref={inputRef}
-                    underlineColorAndroid="transparent"
-                    editable={false}
-                    defaultValue="0"
+            {isValueDisplayed && (
+                <View
                     style={[
-                        { color: textColor ?? color },
-                        styles.value,
-                        valueStyles
-                    ]}
-                />
-
-                <Body
-                    family="semiBold"
-                    style={[
-                        { color: textColor ?? color },
-                        styles.tagline,
-                        taglineStyles
+                        StyleSheet.absoluteFillObject,
+                        {
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                        }
                     ]}>
-                    {tagline}
-                </Body>
-            </View>
+                    <AnimatedTextInput
+                        ref={inputRef}
+                        underlineColorAndroid="transparent"
+                        editable={false}
+                        defaultValue="0"
+                        style={[
+                            { color: textColor ?? color },
+                            styles.value,
+                            valueStyles
+                        ]}
+                    />
+
+                    <Body
+                        family="semiBold"
+                        style={[
+                            { color: textColor ?? color },
+                            styles.tagline,
+                            taglineStyles
+                        ]}>
+                        {tagline}
+                    </Body>
+                </View>
+            )}
         </View>
     );
 };
@@ -179,7 +182,8 @@ AnimatedCircle.proptypes = {
     valueSuffix: PropTypes.string,
     valueStyles: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     tagline: PropTypes.string,
-    taglineStyles: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
+    taglineStyles: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    isValueDisplayed: PropTypes.bool
 };
 
 const styles = StyleSheet.create({

--- a/screens/components/card/IconStatsCard.js
+++ b/screens/components/card/IconStatsCard.js
@@ -6,6 +6,22 @@ import { Title, Caption } from '../typography';
 import { Colors } from '../theme';
 const { width } = Dimensions.get('window');
 
+// fn to get ordinal of number
+export const getOrdinal = number => {
+    const b = number % 10;
+    const output =
+        Math.floor((number % 100) / 10) === 1
+            ? 'th'
+            : b === 1
+            ? 'st'
+            : b === 2
+            ? 'nd'
+            : b === 3
+            ? 'rd'
+            : 'th';
+    return output;
+};
+
 const IconStatsCard = ({
     style,
     value,
@@ -14,6 +30,7 @@ const IconStatsCard = ({
     fontColor = Colors.accent,
     imageContent,
     contentCenter,
+    ordinal,
     backgroundColor = Colors.accentLight
 }) => {
     return (
@@ -42,6 +59,10 @@ const IconStatsCard = ({
                     duration={5}
                     shouldUseToLocaleString
                 />
+                {ordinal &&
+                    value !== 0 &&
+                    value !== undefined &&
+                    getOrdinal(value)}
             </Title>
 
             <Caption
@@ -66,6 +87,7 @@ IconStatsCard.propTypes = {
     fontColor: PropTypes.string,
     backgroundColor: PropTypes.string,
     contentCenter: PropTypes.bool,
+    ordinal: PropTypes.bool,
     imageContent: PropTypes.element
 };
 

--- a/screens/components/card/StatsGrid.js
+++ b/screens/components/card/StatsGrid.js
@@ -25,6 +25,7 @@ const StatsGrid = ({ statsData }) => {
                         contentCenter
                         backgroundColor={stat.bgColor}
                         fontColor={stat.color}
+                        ordinal={stat.ordinal}
                     />
                 ))}
             </View>
@@ -40,7 +41,8 @@ StatsGrid.propTypes = {
             startValue: PropTypes.number,
             icon: PropTypes.string.isRequired,
             color: PropTypes.string.isRequired,
-            bgColor: PropTypes.string.isRequired
+            bgColor: PropTypes.string.isRequired,
+            ordinal: PropTypes.bool
         })
     )
 };

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -79,7 +79,8 @@ class UserStatsScreen extends Component {
                 title: 'Rank',
                 icon: 'ios-podium-outline',
                 color: '#A855F7',
-                bgColor: '#F3E8FF'
+                bgColor: '#F3E8FF',
+                ordinal: true
             },
             {
                 value: user?.total_images || this.state.totalImagesStart,

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -16,8 +16,29 @@ import {
     AnimatedCircle,
     Header,
     Colors,
-    StatsGrid
+    StatsGrid,
+    Caption
 } from '../components';
+
+const ProgressStatCard = ({ value, title, tagline, color, style }) => {
+    return (
+        <View
+            style={[
+                style,
+                {
+                    // borderTopColor: color,
+                    // borderTopWidth: 4,
+                    borderRadius: 8,
+                    paddingLeft: 10,
+                    paddingVertical: 10
+                }
+            ]}>
+            <Title style={{ color }}>{value}</Title>
+            <Body style={{ color }}>{title}</Body>
+            <Caption>{tagline}</Caption>
+        </View>
+    );
+};
 
 class UserStatsScreen extends Component {
     constructor(props) {
@@ -141,25 +162,83 @@ class UserStatsScreen extends Component {
                     }
                 />
                 <ScrollView
-                    contentContainerStyle={{
-                        paddingTop: 20
-                    }}
+                    contentContainerStyle={
+                        {
+                            // paddingTop: 20
+                        }
+                    }
                     style={styles.container}
                     showsVerticalScrollIndicator={false}
                     alwaysBounceVertical={false}>
-                    <AnimatedCircle
-                        strokeWidth={30}
-                        percentage={user.targetPercentage}
-                        color={`${Colors.accent}`}
-                        value={user.level}
-                        delay={500}
-                        duration={5000}
-                        radius={160}
-                        tagline="Level"
-                    />
-                    <Body color="accent" style={{ textAlign: 'center' }}>
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            flex: 1,
+                            margin: 20,
+                            marginTop: 0,
+                            paddingVertical: 20,
+                            borderRadius: 20
+                            // backgroundColor: '#f2fffc'
+                        }}>
+                        <View
+                            style={{
+                                // flex: 1,
+                                flexGrow: 1,
+                                justifyContent: 'center',
+                                alignItems: 'center'
+                            }}>
+                            <View style={{ position: 'absolute' }}>
+                                <AnimatedCircle
+                                    isValueDisplayed={false}
+                                    strokeWidth={10}
+                                    percentage={user.targetPercentage}
+                                    color={`${Colors.accent}`}
+                                    value={user.level}
+                                    delay={500}
+                                    duration={5000}
+                                    radius={70}
+                                    // tagline="Level"
+                                />
+                            </View>
+
+                            <View>
+                                <AnimatedCircle
+                                    isValueDisplayed={false}
+                                    strokeWidth={10}
+                                    percentage={user.targetPercentage + 10}
+                                    color={`#f7ca18`}
+                                    value={user.level}
+                                    delay={500}
+                                    duration={5000}
+                                    radius={90}
+                                    tagline="Level"
+                                />
+                            </View>
+                        </View>
+
+                        <View style={{ flexShrink: 1, padding: 10 }}>
+                            <ProgressStatCard
+                                color={Colors.accent}
+                                value={user.level}
+                                title="Level"
+                                tagline={`${
+                                    user.xpRequired
+                                }XP more to level up`}
+                            />
+                            <ProgressStatCard
+                                style={{ marginTop: 20 }}
+                                color="#f7ca18"
+                                value={`80`}
+                                title="Littercoin"
+                                tagline={`50 images more for next littercoin`}
+                            />
+                        </View>
+                    </View>
+
+                    {/* <Body color="accent" style={{ textAlign: 'center' }}>
                         {user.xpRequired}XP more to level up
-                    </Body>
+                    </Body> */}
 
                     <StatsGrid statsData={statsData} />
                 </ScrollView>

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -4,7 +4,8 @@ import {
     View,
     ScrollView,
     Pressable,
-    ActivityIndicator
+    ActivityIndicator,
+    Dimensions
 } from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import * as actions from '../../actions';
@@ -16,29 +17,10 @@ import {
     AnimatedCircle,
     Header,
     Colors,
-    StatsGrid,
-    Caption
+    StatsGrid
 } from '../components';
-
-const ProgressStatCard = ({ value, title, tagline, color, style }) => {
-    return (
-        <View
-            style={[
-                style,
-                {
-                    // borderTopColor: color,
-                    // borderTopWidth: 4,
-                    borderRadius: 8,
-                    paddingLeft: 10,
-                    paddingVertical: 10
-                }
-            ]}>
-            <Title style={{ color }}>{value}</Title>
-            <Body style={{ color }}>{title}</Body>
-            <Caption>{tagline}</Caption>
-        </View>
-    );
-};
+import { ProgressStatCard } from './_components';
+const { width } = Dimensions.get('window');
 
 class UserStatsScreen extends Component {
     constructor(props) {
@@ -197,7 +179,7 @@ class UserStatsScreen extends Component {
                                     value={user.level}
                                     delay={500}
                                     duration={5000}
-                                    radius={70}
+                                    radius={(width - 40) / 4 - 16}
                                     // tagline="Level"
                                 />
                             </View>
@@ -207,11 +189,11 @@ class UserStatsScreen extends Component {
                                     isValueDisplayed={false}
                                     strokeWidth={10}
                                     percentage={user.targetPercentage + 10}
-                                    color={`#f7ca18`}
+                                    color="#f7ca18"
                                     value={user.level}
                                     delay={500}
                                     duration={5000}
-                                    radius={90}
+                                    radius={(width - 40) / 4}
                                     tagline="Level"
                                 />
                             </View>

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -25,7 +25,7 @@ const { width } = Dimensions.get('window');
 class UserStatsScreen extends Component {
     constructor(props) {
         super(props);
-        // console.log(JSON.stringify(this.props.user, null, '\t'));
+        console.log(JSON.stringify(this.props.user, null, '\t'));
         this.state = {
             xpStart: 0,
             positionStart: 0,
@@ -144,11 +144,6 @@ class UserStatsScreen extends Component {
                     }
                 />
                 <ScrollView
-                    contentContainerStyle={
-                        {
-                            // paddingTop: 20
-                        }
-                    }
                     style={styles.container}
                     showsVerticalScrollIndicator={false}
                     alwaysBounceVertical={false}>
@@ -175,7 +170,7 @@ class UserStatsScreen extends Component {
                                     isValueDisplayed={false}
                                     strokeWidth={10}
                                     percentage={user.targetPercentage}
-                                    color={`${Colors.accent}`}
+                                    color="#e268b3"
                                     value={user.level}
                                     delay={500}
                                     duration={5000}
@@ -188,9 +183,9 @@ class UserStatsScreen extends Component {
                                 <AnimatedCircle
                                     isValueDisplayed={false}
                                     strokeWidth={10}
-                                    percentage={user.targetPercentage + 10}
-                                    color="#f7ca18"
-                                    value={user.level}
+                                    percentage={user?.total_images % 100}
+                                    color="#A46EDA"
+                                    value={user?.total_images % 100}
                                     delay={500}
                                     duration={5000}
                                     radius={(width - 40) / 4}
@@ -201,7 +196,7 @@ class UserStatsScreen extends Component {
 
                         <View style={{ flexShrink: 1, padding: 10 }}>
                             <ProgressStatCard
-                                color={Colors.accent}
+                                color="#e268b3"
                                 value={user.level}
                                 title="Level"
                                 tagline={`${
@@ -210,10 +205,12 @@ class UserStatsScreen extends Component {
                             />
                             <ProgressStatCard
                                 style={{ marginTop: 20 }}
-                                color="#f7ca18"
-                                value={`80`}
+                                color="#A46EDA"
+                                value={user.totalLittercoin}
                                 title="Littercoin"
-                                tagline={`50 images more for next littercoin`}
+                                tagline={`${100 -
+                                    (user?.total_images %
+                                        100)} images more for next littercoin`}
                             />
                         </View>
                     </View>

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -4,28 +4,19 @@ import {
     View,
     ScrollView,
     Pressable,
-    ActivityIndicator,
-    Dimensions
+    ActivityIndicator
 } from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import * as actions from '../../actions';
 import { connect } from 'react-redux';
 import Icon from 'react-native-vector-icons/Ionicons';
-import {
-    Body,
-    Title,
-    AnimatedCircle,
-    Header,
-    Colors,
-    StatsGrid
-} from '../components';
-import { ProgressStatCard } from './_components';
-const { width } = Dimensions.get('window');
+import { Body, Title, Header, Colors, StatsGrid } from '../components';
+import { ProgressCircleCard } from './_components';
 
 class UserStatsScreen extends Component {
     constructor(props) {
         super(props);
-        console.log(JSON.stringify(this.props.user, null, '\t'));
+        // console.log(JSON.stringify(this.props.user, null, '\t'));
         this.state = {
             xpStart: 0,
             positionStart: 0,
@@ -147,77 +138,13 @@ class UserStatsScreen extends Component {
                     style={styles.container}
                     showsVerticalScrollIndicator={false}
                     alwaysBounceVertical={false}>
-                    <View
-                        style={{
-                            flexDirection: 'row',
-                            alignItems: 'center',
-                            flex: 1,
-                            margin: 20,
-                            marginTop: 0,
-                            paddingVertical: 20,
-                            borderRadius: 20
-                            // backgroundColor: '#f2fffc'
-                        }}>
-                        <View
-                            style={{
-                                // flex: 1,
-                                flexGrow: 1,
-                                justifyContent: 'center',
-                                alignItems: 'center'
-                            }}>
-                            <View style={{ position: 'absolute' }}>
-                                <AnimatedCircle
-                                    isValueDisplayed={false}
-                                    strokeWidth={10}
-                                    percentage={user.targetPercentage}
-                                    color="#e268b3"
-                                    value={user.level}
-                                    delay={500}
-                                    duration={5000}
-                                    radius={(width - 40) / 4 - 16}
-                                    // tagline="Level"
-                                />
-                            </View>
-
-                            <View>
-                                <AnimatedCircle
-                                    isValueDisplayed={false}
-                                    strokeWidth={10}
-                                    percentage={user?.total_images % 100}
-                                    color="#A46EDA"
-                                    value={user?.total_images % 100}
-                                    delay={500}
-                                    duration={5000}
-                                    radius={(width - 40) / 4}
-                                    tagline="Level"
-                                />
-                            </View>
-                        </View>
-
-                        <View style={{ flexShrink: 1, padding: 10 }}>
-                            <ProgressStatCard
-                                color="#e268b3"
-                                value={user.level}
-                                title="Level"
-                                tagline={`${
-                                    user.xpRequired
-                                }XP more to level up`}
-                            />
-                            <ProgressStatCard
-                                style={{ marginTop: 20 }}
-                                color="#A46EDA"
-                                value={user.totalLittercoin}
-                                title="Littercoin"
-                                tagline={`${100 -
-                                    (user?.total_images %
-                                        100)} images more for next littercoin`}
-                            />
-                        </View>
-                    </View>
-
-                    {/* <Body color="accent" style={{ textAlign: 'center' }}>
-                        {user.xpRequired}XP more to level up
-                    </Body> */}
+                    <ProgressCircleCard
+                        level={user?.level}
+                        levelPercentage={user?.targetPercentage}
+                        xpRequired={user?.xpRequired}
+                        totalLittercoin={user?.totalLittercoin}
+                        littercoinPercentage={user?.total_images % 100}
+                    />
 
                     <StatsGrid statsData={statsData} />
                 </ScrollView>

--- a/screens/userStats/_components/ProgressCircleCard.js
+++ b/screens/userStats/_components/ProgressCircleCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet, View, Dimensions } from 'react-native';
 import ProgressStatCard from './ProgressStatCard';
 import { AnimatedCircle } from '../../components';
 const { width } = Dimensions.get('window');
@@ -12,33 +12,18 @@ const ProgressCircleCard = ({
     littercoinPercentage
 }) => {
     return (
-        <View
-            style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                flex: 1,
-                marginHorizontal: 20,
-                paddingVertical: 20,
-                borderRadius: 20
-            }}>
-            <View
-                style={{
-                    // flex: 1,
-                    flexGrow: 1,
-                    justifyContent: 'center',
-                    alignItems: 'center'
-                }}>
+        <View style={styles.container}>
+            <View style={styles.circleContainer}>
                 <View style={{ position: 'absolute' }}>
                     <AnimatedCircle
                         isValueDisplayed={false}
                         strokeWidth={10}
                         percentage={levelPercentage}
                         color="#e268b3"
-                        value={level}
+                        value={levelPercentage}
                         delay={500}
                         duration={5000}
                         radius={(width - 40) / 4 - 16}
-                        // tagline="Level"
                     />
                 </View>
 
@@ -52,7 +37,6 @@ const ProgressCircleCard = ({
                         delay={500}
                         duration={5000}
                         radius={(width - 40) / 4}
-                        tagline="Level"
                     />
                 </View>
             </View>
@@ -79,4 +63,18 @@ const ProgressCircleCard = ({
 
 export default ProgressCircleCard;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        flex: 1,
+        marginHorizontal: 20,
+        paddingVertical: 20,
+        borderRadius: 20
+    },
+    circleContainer: {
+        flexGrow: 1,
+        justifyContent: 'center',
+        alignItems: 'center'
+    }
+});

--- a/screens/userStats/_components/ProgressCircleCard.js
+++ b/screens/userStats/_components/ProgressCircleCard.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import ProgressStatCard from './ProgressStatCard';
+import { AnimatedCircle } from '../../components';
+const { width } = Dimensions.get('window');
+
+const ProgressCircleCard = ({
+    level,
+    levelPercentage,
+    xpRequired,
+    totalLittercoin,
+    littercoinPercentage
+}) => {
+    return (
+        <View
+            style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                flex: 1,
+                marginHorizontal: 20,
+                paddingVertical: 20,
+                borderRadius: 20
+            }}>
+            <View
+                style={{
+                    // flex: 1,
+                    flexGrow: 1,
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}>
+                <View style={{ position: 'absolute' }}>
+                    <AnimatedCircle
+                        isValueDisplayed={false}
+                        strokeWidth={10}
+                        percentage={levelPercentage}
+                        color="#e268b3"
+                        value={level}
+                        delay={500}
+                        duration={5000}
+                        radius={(width - 40) / 4 - 16}
+                        // tagline="Level"
+                    />
+                </View>
+
+                <View>
+                    <AnimatedCircle
+                        isValueDisplayed={false}
+                        strokeWidth={10}
+                        percentage={littercoinPercentage}
+                        color="#A46EDA"
+                        value={littercoinPercentage}
+                        delay={500}
+                        duration={5000}
+                        radius={(width - 40) / 4}
+                        tagline="Level"
+                    />
+                </View>
+            </View>
+
+            <View style={{ flexShrink: 1, padding: 10 }}>
+                <ProgressStatCard
+                    color="#e268b3"
+                    value={level}
+                    title="Level"
+                    tagline={`${xpRequired}XP more to level up`}
+                />
+                <ProgressStatCard
+                    style={{ marginTop: 20 }}
+                    color="#A46EDA"
+                    value={totalLittercoin}
+                    title="Littercoin"
+                    tagline={`${100 -
+                        littercoinPercentage} images more for next littercoin`}
+                />
+            </View>
+        </View>
+    );
+};
+
+export default ProgressCircleCard;
+
+const styles = StyleSheet.create({});

--- a/screens/userStats/_components/ProgressStatCard.js
+++ b/screens/userStats/_components/ProgressStatCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import { CountUp } from 'use-count-up';
 import { Title, Body, Caption } from '../../components';
 
 const ProgressStatCard = ({ value, title, tagline, color, style }) => {
@@ -13,7 +14,14 @@ const ProgressStatCard = ({ value, title, tagline, color, style }) => {
                     paddingVertical: 10
                 }
             ]}>
-            <Title style={{ color }}>{value}</Title>
+            <Title style={{ color }}>
+                <CountUp
+                    isCounting
+                    end={value}
+                    duration={5}
+                    shouldUseToLocaleString
+                />
+            </Title>
             <Body style={{ color }}>{title}</Body>
             <Caption>{tagline}</Caption>
         </View>

--- a/screens/userStats/_components/ProgressStatCard.js
+++ b/screens/userStats/_components/ProgressStatCard.js
@@ -8,8 +8,6 @@ const ProgressStatCard = ({ value, title, tagline, color, style }) => {
             style={[
                 style,
                 {
-                    // borderTopColor: color,
-                    // borderTopWidth: 4,
                     borderRadius: 8,
                     paddingLeft: 10,
                     paddingVertical: 10

--- a/screens/userStats/_components/ProgressStatCard.js
+++ b/screens/userStats/_components/ProgressStatCard.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Title, Body, Caption } from '../../components';
+
+const ProgressStatCard = ({ value, title, tagline, color, style }) => {
+    return (
+        <View
+            style={[
+                style,
+                {
+                    // borderTopColor: color,
+                    // borderTopWidth: 4,
+                    borderRadius: 8,
+                    paddingLeft: 10,
+                    paddingVertical: 10
+                }
+            ]}>
+            <Title style={{ color }}>{value}</Title>
+            <Body style={{ color }}>{title}</Body>
+            <Caption>{tagline}</Caption>
+        </View>
+    );
+};
+
+export default ProgressStatCard;

--- a/screens/userStats/_components/index.js
+++ b/screens/userStats/_components/index.js
@@ -1,3 +1,4 @@
 export { default as StatsCard } from './StatsCard';
 export { default as RewardsList } from './RewardsList';
 export { default as ProgressStatCard } from './ProgressStatCard';
+export { default as ProgressCircleCard } from './ProgressCircleCard';

--- a/screens/userStats/_components/index.js
+++ b/screens/userStats/_components/index.js
@@ -1,2 +1,3 @@
 export { default as StatsCard } from './StatsCard';
 export { default as RewardsList } from './RewardsList';
+export { default as ProgressStatCard } from './ProgressStatCard';


### PR DESCRIPTION
- added circular progress for both xp and littercoin in userstats page [trello card](https://trello.com/c/R2R0fzHh)
- added ordinal to rank -- now rank shows like 1st , 2nd etc  [trello card ](https://trello.com/c/EXkphqr4)
- fixed the issue of locationSubscription() not a fn  [trello card ](https://trello.com/c/48Tz6QGM)

**Note**
- for level and littercoin the count for animation starts from 0 . because it looked better with animating circle