### PR TITLE
fix: header stying issues on settings and geotagged screen

### DIFF
--- a/actions/types.js
+++ b/actions/types.js
@@ -4,7 +4,7 @@ import { SECRET_CLIENT } from '@env';
 import { ID_CLIENT } from '@env';
 import { OLM_ENDPOINT } from '@env';
 
-export const IS_PRODUCTION = true; // change this when working locally to disable Sentry
+export const IS_PRODUCTION = false; // change this when working locally to disable Sentry
 
 export const CLIENT_ID = ID_CLIENT;
 export const CLIENT_SECRET = SECRET_CLIENT;

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -46,11 +46,11 @@ class SettingsScreen extends Component {
                     }
                     centerContent={
                         <Title
-                            style={{ marginLeft: 20 }}
                             color="white"
                             dictionary={`${lang}.settings.settings`}
                         />
                     }
+                    centerContainerStyle={{ flex: 2 }}
                     rightContent={
                         <Pressable onPress={() => this.props.logout()}>
                             <Body

--- a/screens/components/Header.js
+++ b/screens/components/Header.js
@@ -15,7 +15,10 @@ const Header = ({
     leftContent,
     centerContent,
     rightContent,
-    containerStyle
+    containerStyle,
+    leftContainerStyle,
+    centerContainerStyle,
+    rightContainerStyle
 }) => {
     return (
         <>
@@ -31,12 +34,18 @@ const Header = ({
                 <View style={[styles.headerContainer, containerStyle]}>
                     {/* left icon */}
                     {leftContent && (
-                        <View style={{ flex: 1 }}>{leftContent}</View>
+                        <View style={[{ flex: 1 }, leftContainerStyle]}>
+                            {leftContent}
+                        </View>
                     )}
 
                     {/* center content */}
                     {centerContent && (
-                        <View style={{ flex: 1, alignItems: 'center' }}>
+                        <View
+                            style={[
+                                { flex: 1, alignItems: 'center' },
+                                centerContainerStyle
+                            ]}>
                             {centerContent}
                         </View>
                     )}
@@ -44,10 +53,13 @@ const Header = ({
                     {/* right content */}
 
                     <View
-                        style={{
-                            flex: 1,
-                            alignItems: 'flex-end'
-                        }}>
+                        style={[
+                            {
+                                flex: 1,
+                                alignItems: 'flex-end'
+                            },
+                            rightContainerStyle
+                        ]}>
                         {rightContent}
                     </View>
                 </View>
@@ -60,7 +72,19 @@ Header.propTypes = {
     leftContent: PropTypes.element,
     rightContent: PropTypes.element,
     centerContent: PropTypes.element,
-    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    leftContainerStyle: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
+    ]),
+    rightContainerStyle: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
+    ]),
+    centerContainerStyle: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
+    ])
 };
 
 export default Header;

--- a/screens/gallery/GalleryScreen.js
+++ b/screens/gallery/GalleryScreen.js
@@ -236,6 +236,7 @@ class GalleryScreen extends Component {
                         </Pressable>
                     }
                     centerContent={<SubTitle color="white">Geotagged</SubTitle>}
+                    centerContainerStyle={{ flex: 2 }}
                     rightContent={
                         <Pressable
                             onPress={async () => {


### PR DESCRIPTION
- Added props to control styling of left, centre, and right container of header.
- Fix header styling issues of Geotagged and setting screen
- Tested on iphone 8