### PR TITLE
fix: android filename issue

### DIFF
--- a/actions/types.js
+++ b/actions/types.js
@@ -4,7 +4,7 @@ import { SECRET_CLIENT } from '@env';
 import { ID_CLIENT } from '@env';
 import { OLM_ENDPOINT } from '@env';
 
-export const IS_PRODUCTION = true; // change this when working locally to disable sentry
+export const IS_PRODUCTION = false; // change this when working locally to disable sentry
 
 export const CLIENT_ID = ID_CLIENT;
 export const CLIENT_SECRET = SECRET_CLIENT;

--- a/screens/camera/CameraScreen.js
+++ b/screens/camera/CameraScreen.js
@@ -254,15 +254,7 @@ class CameraScreen extends React.Component {
                         // timestamp in seconds
                         const date = Date.now() / 1000;
 
-                        // We need to generate a better filename for android
-                        const filename =
-                            Platform.OS === 'android'
-                                ? base64.encode(date) + '.jpg'
-                                : result.uri.split('/').pop();
-
-                        // Example:
-                        // iOS 96790415-6575-4CED-BA64-D6E8B16BF10D.jpg
-                        // Android...
+                        const filename = result.uri.split('/').pop();
 
                         this.props.addImages(
                             [


### PR DESCRIPTION
- Fixes the bug `camera.takePicture [TypeError: input.charCodeAt is not a function. (In 'input.charCodeAt(i++)', 'input.charCodeAt' is undefined)]` on android.
- Android --> `"filename": "dca976b5-5098-4894-bf8e-d717feb291c8.jpg"`
- IOS --> `"filename": "6163ADDE-2DE3-45E3-B71D-CBE4D37C716D.jpg"`

**Trello Card**
[Android filename bug on taking images from OLM camera](https://trello.com/c/eixjsAMv)