### PR TITLE
disable dark mode on ios

### DIFF
--- a/ios/openlittermap/Info.plist
+++ b/ios/openlittermap/Info.plist
@@ -69,6 +69,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+    <string>Light</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Disabled system default dark mode on ios.

**Trello**
[Darkmode colour bug on iOS Login](https://trello.com/c/LRPno0mh)