### PR TITLE
feat: show current index of image

### DIFF
--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -282,71 +282,39 @@ class AddTags extends PureComponent {
 
                         {/* Black overlay */}
                         {this.state.isOverlayDisplayed && (
-                            <View
-                                style={{
-                                    position: 'absolute',
-                                    flex: 1,
-                                    backgroundColor: 'black',
-                                    opacity: 0.4,
-                                    width: SCREEN_WIDTH,
-                                    height: SCREEN_HEIGHT
-                                }}
-                            />
+                            <View style={styles.overlayStyle} />
                         )}
 
-                        <View
-                            style={{
-                                position: 'absolute',
-                                top: 60,
-                                left: 20,
-                                flexDirection: 'row',
-                                justifyContent: 'space-between',
-                                width: SCREEN_WIDTH - 40
-                            }}>
-                            <View
-                                style={{
-                                    minWidth: 100,
-                                    paddingHorizontal: 20,
-                                    height: 40,
-                                    backgroundColor: 'rgba(255, 255, 255, 1)',
-                                    borderRadius: 100,
-                                    justifyContent: 'center',
-                                    alignItems: 'center'
-                                }}>
-                                <Body color="text">
-                                    {this.props.swiperIndex + 1}/
-                                    {this.props.images.length}
-                                </Body>
-                            </View>
-                            <Pressable
-                                onPress={this.props.toggleLitter}
-                                style={{
-                                    width: 40,
-                                    height: 40,
-                                    backgroundColor: 'white',
-                                    borderRadius: 100,
-                                    justifyContent: 'center',
-                                    alignItems: 'center'
-                                }}>
-                                <Icon
-                                    name="ios-close-outline"
-                                    color="black"
-                                    size={32}
-                                />
-                            </Pressable>
-                        </View>
-
-                        {this.state.isOverlayDisplayed && (
+                        {!this.state.isCategoriesVisible && (
                             <View
                                 style={{
                                     position: 'absolute',
-                                    backgroundColor: Colors.white,
-                                    width: SCREEN_WIDTH - 40,
-                                    marginLeft: 20,
-                                    top: 110,
-                                    borderRadius: 12,
-                                    padding: 20
+                                    top: 60,
+                                    left: 20,
+                                    flexDirection: 'row',
+                                    justifyContent: 'space-between',
+                                    width: SCREEN_WIDTH - 40
                                 }}>
+                                <View style={styles.indexStyle}>
+                                    <Body color="text">
+                                        {this.props.swiperIndex + 1}/
+                                        {this.props.images.length}
+                                    </Body>
+                                </View>
+                                <Pressable
+                                    onPress={this.props.toggleLitter}
+                                    style={styles.closeButton}>
+                                    <Icon
+                                        name="ios-close-outline"
+                                        color="black"
+                                        size={32}
+                                    />
+                                </Pressable>
+                            </View>
+                        )}
+
+                        {this.state.isOverlayDisplayed && (
+                            <View style={styles.indexRow}>
                                 <Caption
                                     dictionary={`${lang}.tag.litter-status`}
                                 />
@@ -402,15 +370,7 @@ class AddTags extends PureComponent {
                         {this.state.isCategoriesVisible && (
                             <Animated.View
                                 style={[
-                                    {
-                                        backgroundColor: 'white',
-                                        position: 'absolute',
-                                        bottom: -400,
-                                        left: 0,
-                                        paddingVertical: 20,
-                                        borderTopLeftRadius: 8,
-                                        borderTopRightRadius: 8
-                                    },
+                                    styles.bottomSheet,
                                     sheetAnimatedStyle
                                 ]}>
                                 <View
@@ -554,6 +514,15 @@ const styles = StyleSheet.create({
         flex: 1,
         backgroundColor: 'white'
     },
+    indexRow: {
+        position: 'absolute',
+        backgroundColor: Colors.white,
+        width: SCREEN_WIDTH - 40,
+        marginLeft: 20,
+        top: 110,
+        borderRadius: 12,
+        padding: 20
+    },
     buttonStyle: {
         height: 56,
         width: SCREEN_WIDTH - 40,
@@ -579,6 +548,40 @@ const styles = StyleSheet.create({
         paddingVertical: 12,
         justifyContent: 'center',
         alignItems: 'center'
+    },
+    overlayStyle: {
+        position: 'absolute',
+        flex: 1,
+        backgroundColor: 'black',
+        opacity: 0.4,
+        width: SCREEN_WIDTH,
+        height: SCREEN_HEIGHT
+    },
+    indexStyle: {
+        minWidth: 80,
+        paddingHorizontal: 20,
+        height: 40,
+        backgroundColor: 'rgba(255, 255, 255, 1)',
+        borderRadius: 100,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    closeButton: {
+        width: 40,
+        height: 40,
+        backgroundColor: 'white',
+        borderRadius: 100,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    bottomSheet: {
+        backgroundColor: 'white',
+        position: 'absolute',
+        bottom: -400,
+        left: 0,
+        paddingVertical: 20,
+        borderTopLeftRadius: 8,
+        borderTopRightRadius: 8
     }
 });
 

--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -24,7 +24,8 @@ import {
     LitterPickerWheels,
     LitterTags,
     LitterBottomSearch,
-    TagsActionButton
+    TagsActionButton,
+    LitterTagsCard
 } from './addTagComponents';
 import { SubTitle, Colors, Body, Caption } from '../components';
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -321,6 +322,7 @@ class AddTags extends PureComponent {
                                     marginLeft: 20,
                                     top: 70
                                 }}>
+                                {/* Shows the status of litter if "picked up" or not */}
                                 <View style={styles.statusCard}>
                                     <Caption
                                         dictionary={`${lang}.tag.litter-status`}
@@ -338,63 +340,15 @@ class AddTags extends PureComponent {
                                         />
                                     )}
                                 </View>
-                                <View style={styles.statusCard}>
-                                    <Body>Tags</Body>
-                                    <View>
-                                        {Object.keys(
-                                            this.props.images[
-                                                this.props.swiperIndex
-                                            ]?.tags
-                                        ).map(category => {
-                                            return (
-                                                <View>
-                                                    <Body
-                                                        dictionary={`${
-                                                            this.props.lang
-                                                        }.litter.categories.${category}`}
-                                                    />
-                                                    <View
-                                                        style={{
-                                                            flexDirection:
-                                                                'row',
-                                                            flexWrap: 'wrap'
-                                                        }}>
-                                                        {Object.keys(
-                                                            this.props.images[
-                                                                this.props
-                                                                    .swiperIndex
-                                                            ]?.tags[category]
-                                                        ).map(tag => {
-                                                            const value = this
-                                                                .props.images[
-                                                                this.props
-                                                                    .swiperIndex
-                                                            ]?.tags[category][
-                                                                tag
-                                                            ];
-                                                            return (
-                                                                <>
-                                                                    <Caption
-                                                                        dictionary={`${
-                                                                            this
-                                                                                .props
-                                                                                .lang
-                                                                        }.litter.${category}.${tag}`}
-                                                                    />
-                                                                    <Caption>
-                                                                        :{' '}
-                                                                        {value}
-                                                                        &nbsp;
-                                                                    </Caption>
-                                                                </>
-                                                            );
-                                                        })}
-                                                    </View>
-                                                </View>
-                                            );
-                                        })}
-                                    </View>
-                                </View>
+                                {/* Shows the list of tags */}
+                                <LitterTagsCard
+                                    tags={
+                                        this.props.images[
+                                            this.props.swiperIndex
+                                        ]?.tags
+                                    }
+                                    lang={this.props.lang}
+                                />
                             </View>
                         )}
 

--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -13,7 +13,6 @@ import {
     StyleSheet,
     Pressable
 } from 'react-native';
-
 import Swiper from 'react-native-swiper';
 import { connect } from 'react-redux';
 import LottieView from 'lottie-react-native';
@@ -294,6 +293,49 @@ class AddTags extends PureComponent {
                                 }}
                             />
                         )}
+
+                        <View
+                            style={{
+                                position: 'absolute',
+                                top: 60,
+                                left: 20,
+                                flexDirection: 'row',
+                                justifyContent: 'space-between',
+                                width: SCREEN_WIDTH - 40
+                            }}>
+                            <View
+                                style={{
+                                    minWidth: 100,
+                                    paddingHorizontal: 20,
+                                    height: 40,
+                                    backgroundColor: 'rgba(255, 255, 255, 1)',
+                                    borderRadius: 100,
+                                    justifyContent: 'center',
+                                    alignItems: 'center'
+                                }}>
+                                <Body color="text">
+                                    {this.props.swiperIndex + 1}/
+                                    {this.props.images.length}
+                                </Body>
+                            </View>
+                            <Pressable
+                                onPress={this.props.toggleLitter}
+                                style={{
+                                    width: 40,
+                                    height: 40,
+                                    backgroundColor: 'white',
+                                    borderRadius: 100,
+                                    justifyContent: 'center',
+                                    alignItems: 'center'
+                                }}>
+                                <Icon
+                                    name="ios-close-outline"
+                                    color="black"
+                                    size={32}
+                                />
+                            </Pressable>
+                        </View>
+
                         {this.state.isOverlayDisplayed && (
                             <View
                                 style={{
@@ -301,7 +343,7 @@ class AddTags extends PureComponent {
                                     backgroundColor: Colors.white,
                                     width: SCREEN_WIDTH - 40,
                                     marginLeft: 20,
-                                    top: 100,
+                                    top: 110,
                                     borderRadius: 12,
                                     padding: 20
                                 }}>

--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -3,17 +3,16 @@ import {
     Dimensions,
     Keyboard,
     Platform,
-    SafeAreaView,
     StatusBar,
     TouchableOpacity,
     View,
-    Text,
     Animated,
     Easing,
     StyleSheet,
     Pressable
 } from 'react-native';
 import Swiper from 'react-native-swiper';
+import GestureRecognizer from 'react-native-swipe-gestures';
 import { connect } from 'react-redux';
 import LottieView from 'lottie-react-native';
 import ActionSheet from 'react-native-actions-sheet';
@@ -31,7 +30,6 @@ import { SubTitle, Colors, Body, Caption } from '../components';
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 
-import LITTERKEYS from '../../assets/data/litterkeys';
 import Icon from 'react-native-vector-icons/Ionicons';
 
 class AddTags extends PureComponent {
@@ -282,54 +280,121 @@ class AddTags extends PureComponent {
 
                         {/* Black overlay */}
                         {this.state.isOverlayDisplayed && (
-                            <View style={styles.overlayStyle} />
+                            <GestureRecognizer
+                                onSwipeDown={state => {
+                                    this.props.toggleLitter();
+                                }}>
+                                <View style={styles.overlayStyle} />
+                            </GestureRecognizer>
                         )}
 
-                        {!this.state.isCategoriesVisible && (
+                        <View
+                            style={{
+                                position: 'absolute',
+                                top: 20,
+                                left: 20,
+                                flexDirection: 'row',
+                                justifyContent: 'space-between',
+                                width: SCREEN_WIDTH - 40
+                            }}>
+                            <View style={styles.indexStyle}>
+                                <Body color="text">
+                                    {this.props.swiperIndex + 1}/
+                                    {this.props.images.length}
+                                </Body>
+                            </View>
+                            <Pressable
+                                onPress={this.props.toggleLitter}
+                                style={styles.closeButton}>
+                                <Icon
+                                    name="ios-close-outline"
+                                    color="black"
+                                    size={32}
+                                />
+                            </Pressable>
+                        </View>
+
+                        {this.state.isOverlayDisplayed && (
                             <View
                                 style={{
                                     position: 'absolute',
-                                    top: 60,
-                                    left: 20,
-                                    flexDirection: 'row',
-                                    justifyContent: 'space-between',
-                                    width: SCREEN_WIDTH - 40
+                                    marginLeft: 20,
+                                    top: 70
                                 }}>
-                                <View style={styles.indexStyle}>
-                                    <Body color="text">
-                                        {this.props.swiperIndex + 1}/
-                                        {this.props.images.length}
-                                    </Body>
+                                <View style={styles.statusCard}>
+                                    <Caption
+                                        dictionary={`${lang}.tag.litter-status`}
+                                    />
+                                    {this.props.images[this.props.swiperIndex]
+                                        ?.picked_up ? (
+                                        <Body
+                                            color="accent"
+                                            dictionary={`${lang}.tag.picked-thumb`}
+                                        />
+                                    ) : (
+                                        <Body
+                                            color="error"
+                                            dictionary={`${lang}.tag.not-picked-thumb`}
+                                        />
+                                    )}
                                 </View>
-                                <Pressable
-                                    onPress={this.props.toggleLitter}
-                                    style={styles.closeButton}>
-                                    <Icon
-                                        name="ios-close-outline"
-                                        color="black"
-                                        size={32}
-                                    />
-                                </Pressable>
-                            </View>
-                        )}
-
-                        {this.state.isOverlayDisplayed && (
-                            <View style={styles.indexRow}>
-                                <Caption
-                                    dictionary={`${lang}.tag.litter-status`}
-                                />
-                                {this.props.images[this.props.swiperIndex]
-                                    ?.picked_up ? (
-                                    <Body
-                                        color="accent"
-                                        dictionary={`${lang}.tag.picked-thumb`}
-                                    />
-                                ) : (
-                                    <Body
-                                        color="error"
-                                        dictionary={`${lang}.tag.not-picked-thumb`}
-                                    />
-                                )}
+                                <View style={styles.statusCard}>
+                                    <Body>Tags</Body>
+                                    <View>
+                                        {Object.keys(
+                                            this.props.images[
+                                                this.props.swiperIndex
+                                            ]?.tags
+                                        ).map(category => {
+                                            return (
+                                                <View>
+                                                    <Body
+                                                        dictionary={`${
+                                                            this.props.lang
+                                                        }.litter.categories.${category}`}
+                                                    />
+                                                    <View
+                                                        style={{
+                                                            flexDirection:
+                                                                'row',
+                                                            flexWrap: 'wrap'
+                                                        }}>
+                                                        {Object.keys(
+                                                            this.props.images[
+                                                                this.props
+                                                                    .swiperIndex
+                                                            ]?.tags[category]
+                                                        ).map(tag => {
+                                                            const value = this
+                                                                .props.images[
+                                                                this.props
+                                                                    .swiperIndex
+                                                            ]?.tags[category][
+                                                                tag
+                                                            ];
+                                                            return (
+                                                                <>
+                                                                    <Caption
+                                                                        dictionary={`${
+                                                                            this
+                                                                                .props
+                                                                                .lang
+                                                                        }.litter.${category}.${tag}`}
+                                                                    />
+                                                                    <Caption>
+                                                                        :{' '}
+                                                                        {value}
+                                                                        &nbsp;
+                                                                    </Caption>
+                                                                </>
+                                                            );
+                                                        })}
+                                                    </View>
+                                                </View>
+                                            );
+                                        })}
+                                    </View>
+                                </View>
                             </View>
                         )}
 
@@ -514,14 +579,12 @@ const styles = StyleSheet.create({
         flex: 1,
         backgroundColor: 'white'
     },
-    indexRow: {
-        position: 'absolute',
+    statusCard: {
         backgroundColor: Colors.white,
         width: SCREEN_WIDTH - 40,
-        marginLeft: 20,
-        top: 110,
         borderRadius: 12,
-        padding: 20
+        padding: 20,
+        marginBottom: 20
     },
     buttonStyle: {
         height: 56,
@@ -552,7 +615,7 @@ const styles = StyleSheet.create({
     overlayStyle: {
         position: 'absolute',
         flex: 1,
-        backgroundColor: 'black',
+        backgroundColor: 'red',
         opacity: 0.4,
         width: SCREEN_WIDTH,
         height: SCREEN_HEIGHT

--- a/screens/addTag/addTagComponents/LitterTagsCard.js
+++ b/screens/addTag/addTagComponents/LitterTagsCard.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { Colors, Body, Caption } from '../../components';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+/**
+ * component to show added tags on image when AddTags screen is opened
+ * shown below Litter Status card
+ *
+ * Loop over Array of keys of tag Object to get Categories
+ * Then loop again Key of categories Object to get individual tag and its quantity
+ *
+ * tag : {
+ * "category" : {
+ *          "tag1" : quantity
+ *          }
+ * }
+ * @param {Object} tag -- > Object of tags
+ * @param {String} lang --> Selected Global Language
+ * @returns
+ */
+const LitterTagsCard = ({ tags, lang }) => {
+    return (
+        <>
+            {/* Only show if atleast one tag is present */}
+            {Object.keys(tags).length !== 0 && (
+                <View style={styles.card}>
+                    <Caption>Tags</Caption>
+
+                    <View style={{ marginTop: 8 }}>
+                        {Object.keys(tags).map(category => {
+                            return (
+                                <View>
+                                    <Body
+                                        dictionary={`${lang}.litter.categories.${category}`}
+                                    />
+                                    <View
+                                        style={{
+                                            flexDirection: 'row',
+                                            flexWrap: 'wrap'
+                                        }}>
+                                        {Object.keys(tags[category]).map(
+                                            tag => {
+                                                const value =
+                                                    tags[category][tag];
+                                                return (
+                                                    <View
+                                                        key={tag}
+                                                        style={
+                                                            styles.tagBadges
+                                                        }>
+                                                        <Caption
+                                                            color="text"
+                                                            dictionary={`${lang}.litter.${category}.${tag}`}
+                                                        />
+                                                        <Caption color="text">
+                                                            : {value} &nbsp;
+                                                        </Caption>
+                                                    </View>
+                                                );
+                                            }
+                                        )}
+                                    </View>
+                                </View>
+                            );
+                        })}
+                    </View>
+                </View>
+            )}
+        </>
+    );
+};
+
+export default LitterTagsCard;
+
+const styles = StyleSheet.create({
+    card: {
+        backgroundColor: Colors.white,
+        width: SCREEN_WIDTH - 40,
+        borderRadius: 12,
+        padding: 20,
+        marginBottom: 20
+    },
+    tagBadges: {
+        flexDirection: 'row',
+        backgroundColor: Colors.accentLight,
+        marginRight: 10,
+        marginVertical: 4,
+        borderRadius: 100,
+        paddingHorizontal: 16,
+        paddingVertical: 4
+    }
+});

--- a/screens/addTag/addTagComponents/TagsActionButton.js
+++ b/screens/addTag/addTagComponents/TagsActionButton.js
@@ -12,6 +12,10 @@ class TagsActionButton extends Component {
         isClosed: true
     };
 
+    componentDidMount() {
+        this.showButtons();
+    }
+
     startAnimation = () => {
         Animated.timing(this.state.animation, {
             toValue: -120,
@@ -57,6 +61,12 @@ class TagsActionButton extends Component {
             easing: Easing.elastic(1)
         }).start(() => this.setState({ isClosed: true }));
     };
+
+    showButtons = () => {
+        this.props.toggleOverlay();
+        this.state.isClosed ? this.startAnimation() : this.returnAnimation();
+    };
+
     render() {
         const animatedStyle = {
             transform: [{ translateY: this.state.animation }]
@@ -122,12 +132,7 @@ class TagsActionButton extends Component {
 
                     <AnimatedPressable
                         style={[styles.mainButton, animatedMainButton]}
-                        onPress={() => {
-                            this.props.toggleOverlay();
-                            this.state.isClosed
-                                ? this.startAnimation()
-                                : this.returnAnimation();
-                        }}>
+                        onPress={this.showButtons}>
                         <Icon name="ios-add" color={Colors.white} size={42} />
                     </AnimatedPressable>
                 </View>

--- a/screens/addTag/addTagComponents/index.js
+++ b/screens/addTag/addTagComponents/index.js
@@ -4,3 +4,4 @@ export { default as LitterPickerWheels } from './LitterPickerWheels';
 export { default as LitterTags } from './LitterTags';
 export { default as LitterBottomSearch } from './LitterBottomSearch';
 export { default as TagsActionButton } from './TagsActionButton';
+export { default as LitterTagsCard } from './LitterTagsCard';


### PR DESCRIPTION
- Show current index / total images on AddTags screen
- Shows all icons, options, tags, litter status on the selected image by default
- New card that shows selected tags on image below litter status

**Trello Card**
[Show index / total photos somewhere](https://trello.com/c/djseRcxJ)
[Show all icons, options, tags, litter status on the selected image by default](https://trello.com/c/KNe0ssjc)
[New card to show tags on image](https://trello.com/c/sz5seox3)