### PR TITLE
fix: reduce margin of buttons on android

### DIFF
--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -645,7 +645,7 @@ const styles = StyleSheet.create({
         height: 56,
         width: SCREEN_WIDTH * 0.6,
         backgroundColor: Colors.accent,
-        marginBottom: 40,
+        marginBottom: Platform.OS === 'ios' ? 40 : 0,
         marginLeft: 20,
         justifyContent: 'center',
         alignItems: 'center',


### PR DESCRIPTION
- Reduce bottom margin for ADD Tag button on android

**Trello Card**
[Android / small screens AddTags screen](https://trello.com/c/grdlBRlW)

<img width="407" alt="Screenshot 2022-01-03 at 8 40 33 PM" src="https://user-images.githubusercontent.com/26044934/147946859-7cccfee1-106c-4056-a78f-5ee5e49bdef7.png">
