### PR TITLE
fix: translation error after adding tags from suggested tags

### DIFF
--- a/screens/addTag/addTagComponents/LitterBottomSearch.js
+++ b/screens/addTag/addTagComponents/LitterBottomSearch.js
@@ -29,9 +29,6 @@ class LitterBottomSearch extends PureComponent {
      * A tag has been selected
      */
     addTag(tag) {
-        // update selected tag to execute scrollTo
-        this.props.changeItem(tag);
-
         const newTag = {
             category: tag.category,
             title: tag.key


### PR DESCRIPTION
- This PR fixes the issue of `Error Translation` on adding a tag from tag picker wheel (without scrolling) after adding a tag from suggested/searched tags.

- Issue caused by old code which was not deleted after refactor.

**Trello Card**
[Translation Error after doing Search and add tag](https://trello.com/c/IFX6GzMh)