### PR TITLE
fix: padding issues on scrollviews

### DIFF
--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -326,7 +326,6 @@ class AddTags extends Component {
                                     {
                                         position: 'absolute',
                                         top: -150,
-                                        left: 20,
                                         zIndex: 2
                                     },
                                     categoryAnimatedStyle,

--- a/screens/addTag/addTagComponents/LitterBottomSearch.js
+++ b/screens/addTag/addTagComponents/LitterBottomSearch.js
@@ -124,18 +124,21 @@ class LitterBottomSearch extends PureComponent {
 
                 {this.props.isKeyboardOpen && (
                     <View style={styles.tagsOuterContainer}>
-                        <Caption
-                            style={styles.suggest}
-                            dictionary={`${lang}.tag.suggested-tags`}
-                            values={{
-                                count:
-                                    this.state.text === ''
-                                        ? this.props.previousTags.length
-                                        : this.props.suggestedTags.length
-                            }}
-                        />
+                        <View style={styles.suggest}>
+                            <Caption
+                                dictionary={`${lang}.tag.suggested-tags`}
+                                values={{
+                                    count:
+                                        this.state.text === ''
+                                            ? this.props.previousTags.length
+                                            : this.props.suggestedTags.length
+                                }}
+                            />
+                        </View>
 
                         <FlatList
+                            showsHorizontalScrollIndicator={false}
+                            contentContainerStyle={{ paddingHorizontal: 10 }}
                             data={
                                 this.state.text === ''
                                     ? this.props.previousTags
@@ -172,18 +175,25 @@ const styles = StyleSheet.create({
         fontSize: SCREEN_HEIGHT * 0.02
     },
     suggest: {
-        marginBottom: SCREEN_HEIGHT * 0.01
+        marginBottom: 8,
+        marginLeft: 20,
+        backgroundColor: 'white',
+        paddingHorizontal: 10,
+        paddingVertical: 2,
+        borderRadius: 100,
+        justifyContent: 'center',
+        alignItems: 'center',
+        alignSelf: 'flex-start'
     },
     tag: {
         padding: 10,
         backgroundColor: 'white',
         borderRadius: 8,
-        marginRight: 10,
+        marginHorizontal: 10,
         borderWidth: 1,
         borderColor: Colors.muted
     },
     tagsOuterContainer: {
-        marginLeft: 20,
         marginBottom: 40
     }
 });

--- a/screens/addTag/addTagComponents/LitterCategories.js
+++ b/screens/addTag/addTagComponents/LitterCategories.js
@@ -51,6 +51,7 @@ class LitterCategories extends PureComponent {
         return (
             <View style={{ marginVertical: 20 }}>
                 <FlatList
+                    contentContainerStyle={{ paddingHorizontal: 10 }}
                     showsHorizontalScrollIndicator={false}
                     data={this.props.categories}
                     horizontal={true}

--- a/screens/addTag/addTagComponents/LitterTags.js
+++ b/screens/addTag/addTagComponents/LitterTags.js
@@ -86,10 +86,10 @@ class LitterTags extends Component {
         return (
             <View
                 style={{
-                    marginLeft: 10,
                     width: SCREEN_WIDTH
                 }}>
                 <ScrollView
+                    contentContainerStyle={{ paddingHorizontal: 10 }}
                     ref={this.scrollRef}
                     bounces={false}
                     horizontal={true}


### PR DESCRIPTION
- Fixed padding issue on littercategories scrollview
- Fixed padding issues on tags and suggested tags scrollviews
- Add white background on Suggested Tags text for better readability

**Trello Cards**
[Add padding to the end of categories Flatlist](https://trello.com/c/SQ1rl0zC)
[Suggested Tag text not visible](https://trello.com/c/57eOejgc)