### PR TITLE
refactor: team list card

### DIFF
--- a/actions/teams_action.js
+++ b/actions/teams_action.js
@@ -32,24 +32,7 @@ export const changeActiveTeam = (token, teamId) => {
             });
         } catch (error) {
             console.log(error);
-            // if (error.response) {
-            //     let payload = 'Something went wrong, please try again';
-            //     if (error.response?.status === 422) {
-            //         const errorData = error.response?.data?.errors;
 
-            //         payload = errorData?.name || errorData?.identifier;
-            //     }
-
-            //     dispatch({
-            //         type: TEAMS_FORM_ERROR,
-            //         payload: payload
-            //     });
-            // } else {
-            //     dispatch({
-            //         type: TEAMS_FORM_ERROR,
-            //         payload: 'Network Error, please try again'
-            //     });
-            // }
             return;
         }
 

--- a/screens/team/TeamLeaderboardScreen.js
+++ b/screens/team/TeamLeaderboardScreen.js
@@ -6,7 +6,7 @@ import {
     ActivityIndicator
 } from 'react-native';
 import React, { Component } from 'react';
-import { Header, Colors, Body, SubTitle } from '../components';
+import { Header, Colors, Body, Title, SubTitle } from '../components';
 import * as actions from '../../actions';
 import { connect } from 'react-redux';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -41,6 +41,7 @@ class TeamLeaderboardScreen extends Component {
         this.setState({ isLoading: false });
     };
     render() {
+        const { selectedTeam } = this.props;
         return (
             <>
                 <Header
@@ -60,7 +61,11 @@ class TeamLeaderboardScreen extends Component {
                     centerContainerStyle={{ flex: 2 }}
                 />
                 <View style={styles.container}>
+                    <Title style={{ textAlign: 'center' }}>
+                        {selectedTeam.identifier}
+                    </Title>
                     <FlatList
+                        contentContainerStyle={styles.flatListStyle}
                         alwaysBounceVertical={false}
                         data={this.props.teamMembers}
                         showsVerticalScrollIndicator={false}
@@ -102,6 +107,10 @@ const styles = StyleSheet.create({
         backgroundColor: 'white',
         flex: 1,
         padding: 20
+    },
+    flatListStyle: {
+        marginVertical: 20,
+        paddingBottom: 20
     }
 });
 

--- a/screens/team/teamComponents/TeamListCard.js
+++ b/screens/team/teamComponents/TeamListCard.js
@@ -1,0 +1,52 @@
+import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import RankingMedal from './RankingMedal';
+import { Body, Caption } from '../../components';
+
+const TeamListCard = ({ team, index, showRanking = true, leftContent }) => {
+    return (
+        <View key={`${team.name}${index}`} style={styles.itemContainer}>
+            <View style={styles.titleRow}>
+                {showRanking ? <RankingMedal index={index} /> : leftContent}
+
+                <View style={styles.centerContainer}>
+                    <Body style={{ flexShrink: 1 }} numberOfLines={2}>
+                        {team.name}
+                    </Body>
+
+                    <Caption>
+                        {team.total_images.toLocaleString()} PHOTOS
+                    </Caption>
+                </View>
+            </View>
+            <View style={styles.rightContainer}>
+                <Caption style={styles.alignRight}>
+                    {team.total_litter.toLocaleString()}
+                </Caption>
+                <Caption style={styles.alignRight}>LITTER</Caption>
+            </View>
+        </View>
+    );
+};
+
+export default TeamListCard;
+
+const styles = StyleSheet.create({
+    itemContainer: {
+        height: 60,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+    },
+    titleRow: {
+        flexDirection: 'row',
+        flexShrink: 1
+    },
+    alignRight: {
+        textAlign: 'right'
+    },
+    centerContainer: {
+        marginHorizontal: 20
+    },
+    rightContainer: { marginLeft: 20 }
+});

--- a/screens/team/teamComponents/TopTeamsList.js
+++ b/screens/team/teamComponents/TopTeamsList.js
@@ -1,43 +1,16 @@
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 import React from 'react';
-import Icon from 'react-native-vector-icons/Ionicons';
-import { SubTitle, Body, Caption, Colors } from '../../components';
-import RankingMedal from './RankingMedal';
+import TeamListCard from './TeamListCard';
 
-const { width } = Dimensions.get('window');
 const TopTeamsList = ({ topTeams }) => {
     return (
         <>
             {topTeams.map((team, index) => (
-                <View key={`${team.name}${index}`} style={styles.itemContainer}>
-                    <View
-                        style={{
-                            flexDirection: 'row',
-                            marginRight: 10,
-                            flexShrink: 1
-                        }}>
-                        <RankingMedal index={index} />
-
-                        <View
-                            style={{
-                                marginLeft: 20
-                            }}>
-                            <Body style={{ flexShrink: 1 }} numberOfLines={2}>
-                                {team.name}
-                            </Body>
-
-                            <Caption>
-                                {team.total_images.toLocaleString()} PHOTOS
-                            </Caption>
-                        </View>
-                    </View>
-                    <View>
-                        <Caption style={styles.alignRight}>
-                            {team.total_litter.toLocaleString()}
-                        </Caption>
-                        <Caption style={styles.alignRight}>LITTER</Caption>
-                    </View>
-                </View>
+                <TeamListCard
+                    team={team}
+                    key={`${team.name}${index}`}
+                    index={index}
+                />
             ))}
         </>
     );
@@ -45,14 +18,4 @@ const TopTeamsList = ({ topTeams }) => {
 
 export default TopTeamsList;
 
-const styles = StyleSheet.create({
-    itemContainer: {
-        height: 60,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center'
-    },
-    alignRight: {
-        textAlign: 'right'
-    }
-});
+const styles = StyleSheet.create({});

--- a/screens/team/teamComponents/UserTeamsList.js
+++ b/screens/team/teamComponents/UserTeamsList.js
@@ -4,6 +4,7 @@ import Icon from 'react-native-vector-icons/Ionicons';
 import { SubTitle, Body, Caption, Colors } from '../../components';
 import * as actions from '../../../actions';
 import { connect } from 'react-redux';
+import TeamListCard from './TeamListCard';
 
 class UserTeamsList extends Component {
     componentDidMount() {
@@ -28,37 +29,23 @@ class UserTeamsList extends Component {
                 {userTeams?.map((team, index) => (
                     <Pressable
                         onPress={() => this.setTeam(team)}
-                        key={`${team.name}${index}`}
-                        style={styles.itemContainer}>
-                        <View
-                            style={{
-                                flexDirection: 'row',
-                                justifyContent: 'space-between',
-                                alignItems: 'center'
-                            }}>
-                            {activeTeam === team.id && (
-                                <Icon
-                                    name="ios-star-sharp"
-                                    size={24}
-                                    color={Colors.accent}
-                                />
-                            )}
-                            <View
-                                style={{
-                                    marginLeft: activeTeam !== team.id ? 44 : 20
-                                }}>
-                                <Body>{team.name}</Body>
-                                <Caption>
-                                    {team.total_images.toLocaleString()} PHOTOS
-                                </Caption>
-                            </View>
-                        </View>
-                        <View>
-                            <Caption style={styles.alignRight}>
-                                {team.total_litter.toLocaleString()}
-                            </Caption>
-                            <Caption style={styles.alignRight}>LITTER</Caption>
-                        </View>
+                        key={`${team.name}${index}`}>
+                        <TeamListCard
+                            team={team}
+                            index={index}
+                            showRanking={false}
+                            leftContent={
+                                <View style={{ height: 24, width: 24 }}>
+                                    {activeTeam === team.id && (
+                                        <Icon
+                                            name="ios-star-sharp"
+                                            size={24}
+                                            color={Colors.accent}
+                                        />
+                                    )}
+                                </View>
+                            }
+                        />
                     </Pressable>
                 ))}
             </>
@@ -85,13 +72,6 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'baseline'
-    },
-    itemContainer: {
-        height: 60,
-        // backgroundColor: Colors.accentLight,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center'
     },
     alignRight: {
         textAlign: 'right'

--- a/screens/team/teamComponents/index.js
+++ b/screens/team/teamComponents/index.js
@@ -4,3 +4,4 @@ export { default as TopTeamsList } from './TopTeamsList';
 export { default as JoinTeamForm } from './JoinTeamForm';
 export { default as CreateTeamForm } from './CreateTeamForm';
 export { default as MemberCard } from './MemberCard';
+export { default as TeamListCard } from './TeamListCard';


### PR DESCRIPTION
- Refactor code to use same `teams card` component for Top teams and user teams.
- Tweak margins on card for better text wrapping on long team names