### PR TITLE
fix: Cameraroll pkg fetching initial images only android SDK30 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "openlittermap",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openlittermap",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "dependencies": {
         "@react-native-community/async-storage": "^1.12.1",
-        "@react-native-community/cameraroll": "^4.0.4",
+        "@react-native-community/cameraroll": "github:sudoDeznit/react-native-cameraroll",
         "@react-native-community/clipboard": "^1.5.1",
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-community/picker": "^1.8.1",
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@react-native-community/cameraroll": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.0.4.tgz",
-      "integrity": "sha512-3SY96Xh1yQjV5M7dFisl5kQmrO/K09URarZwmTN801KEalOoo/opsd/e8Vu1dwSKe0NGCK7A2u0oJQpeNbWbnA==",
+      "version": "4.1.2",
+      "resolved": "git+ssh://git@github.com/sudoDeznit/react-native-cameraroll.git#fe28d99d7c210c6bfe7151eb02f6891be87a70bc",
+      "license": "MIT",
       "peerDependencies": {
         "react": "16 || 17",
         "react-native": ">=0.60"
@@ -22261,9 +22261,8 @@
       }
     },
     "@react-native-community/cameraroll": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.0.4.tgz",
-      "integrity": "sha512-3SY96Xh1yQjV5M7dFisl5kQmrO/K09URarZwmTN801KEalOoo/opsd/e8Vu1dwSKe0NGCK7A2u0oJQpeNbWbnA==",
+      "version": "git+ssh://git@github.com/sudoDeznit/react-native-cameraroll.git#fe28d99d7c210c6bfe7151eb02f6891be87a70bc",
+      "from": "@react-native-community/cameraroll@git+https://github.com/sudoDeznit/react-native-cameraroll.git",
       "requires": {}
     },
     "@react-native-community/cli-debugger-ui": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.1",
-    "@react-native-community/cameraroll": "^4.0.4",
+    "@react-native-community/cameraroll": "github:sudoDeznit/react-native-cameraroll",
     "@react-native-community/clipboard": "^1.5.1",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/picker": "^1.8.1",


### PR DESCRIPTION
- react-native-cameraroll only fetches initial images `after` option not working.  https://github.com/react-native-cameraroll/react-native-cameraroll/issues/359
- Used a fork of package with fix for the issue.

**Trello**
[Android issues](https://trello.com/c/jU9DDV1G)