### PR TITLE
feat: adding team title on leaderboard screen

### DIFF
--- a/screens/team/TeamDetailsScreen.js
+++ b/screens/team/TeamDetailsScreen.js
@@ -4,24 +4,14 @@ import {
     ScrollView,
     View,
     Dimensions,
-    Pressable,
-    Animated,
-    Easing
+    Pressable
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
-import Clipboard from '@react-native-community/clipboard';
 import ActionSheet from 'react-native-actions-sheet';
-import {
-    Header,
-    Title,
-    Colors,
-    Body,
-    StatsGrid,
-    Button,
-    Caption
-} from '../components';
+import { Header, Colors, Body, StatsGrid, Button } from '../components';
 import * as actions from '../../actions';
 import { connect } from 'react-redux';
+import { TeamTitle } from './teamComponents';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 class TeamDetailsScreen extends Component {
@@ -30,7 +20,6 @@ class TeamDetailsScreen extends Component {
         this.actionSheetRef = createRef();
 
         this.state = {
-            opacityAnimation: new Animated.Value(0),
             isLoading: false
         };
     }
@@ -59,40 +48,7 @@ class TeamDetailsScreen extends Component {
         this.props.navigation.navigate('TEAM_HOME');
     };
 
-    /**
-     * copy team unique identifier to Clipboard
-     */
-    copyIdentifier = async () => {
-        Clipboard.setString(this.props.selectedTeam?.identifier);
-        this.opacityAnmiation();
-    };
-
-    /**
-     * opactity animations for Copied message
-     */
-    opacityAnmiation = async () => {
-        Animated.timing(this.state.opacityAnimation, {
-            toValue: 1,
-            duration: 500,
-            useNativeDriver: true,
-            easing: Easing.elastic(1)
-        }).start(this.returnOpacityAnmiation);
-    };
-
-    returnOpacityAnmiation = async () => {
-        Animated.timing(this.state.opacityAnimation, {
-            toValue: 0,
-            duration: 800,
-            useNativeDriver: true,
-            easing: Easing.elastic(1)
-        }).start();
-    };
-
     render() {
-        const opacityStyle = {
-            opacity: this.state.opacityAnimation
-        };
-
         const { lang, selectedTeam, user, token } = this.props;
         const isActiveTeam = user.active_team === selectedTeam?.id;
         const teamStats = [
@@ -136,27 +92,10 @@ class TeamDetailsScreen extends Component {
                 <ScrollView
                     style={styles.container}
                     alwaysBounceVertical={false}>
-                    <Pressable
-                        onPress={this.copyIdentifier}
-                        style={styles.titleContainer}>
-                        <Title>{selectedTeam?.name}</Title>
-                        <View style={{ flexDirection: 'row' }}>
-                            <Body color="accent" style={{ marginRight: 10 }}>
-                                {selectedTeam.identifier}
-                            </Body>
-                            <Icon
-                                name="ios-copy-outline"
-                                color={Colors.accent}
-                                size={18}
-                            />
-                        </View>
-                    </Pressable>
-                    {/* Copied message */}
-                    <Animated.View style={opacityStyle}>
-                        <Caption color="accent" style={{ textAlign: 'center' }}>
-                            Copied
-                        </Caption>
-                    </Animated.View>
+                    <TeamTitle
+                        teamName={selectedTeam?.name}
+                        identifier={selectedTeam.identifier}
+                    />
 
                     <StatsGrid statsData={teamStats} />
                     <View style={styles.buttonContainer}>
@@ -241,11 +180,6 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: 'white'
-    },
-    titleContainer: {
-        justifyContent: 'center',
-        alignItems: 'center',
-        marginTop: 20
     },
     actionButtonStyle: {
         height: 48,

--- a/screens/team/TeamLeaderboardScreen.js
+++ b/screens/team/TeamLeaderboardScreen.js
@@ -10,7 +10,7 @@ import { Header, Colors, Body, Title, SubTitle } from '../components';
 import * as actions from '../../actions';
 import { connect } from 'react-redux';
 import Icon from 'react-native-vector-icons/Ionicons';
-import { MemberCard } from './teamComponents';
+import { MemberCard, TeamTitle } from './teamComponents';
 
 class TeamLeaderboardScreen extends Component {
     constructor(props) {
@@ -61,9 +61,10 @@ class TeamLeaderboardScreen extends Component {
                     centerContainerStyle={{ flex: 2 }}
                 />
                 <View style={styles.container}>
-                    <Title style={{ textAlign: 'center' }}>
-                        {selectedTeam.identifier}
-                    </Title>
+                    <TeamTitle
+                        teamName={selectedTeam?.name}
+                        identifier={selectedTeam.identifier}
+                    />
                     <FlatList
                         contentContainerStyle={styles.flatListStyle}
                         alwaysBounceVertical={false}
@@ -106,6 +107,7 @@ const styles = StyleSheet.create({
     container: {
         backgroundColor: 'white',
         flex: 1,
+        paddingTop: 0,
         padding: 20
     },
     flatListStyle: {

--- a/screens/team/teamComponents/TeamTitle.js
+++ b/screens/team/teamComponents/TeamTitle.js
@@ -1,0 +1,99 @@
+import {
+    Text,
+    View,
+    Animated,
+    Easing,
+    Pressable,
+    StyleSheet
+} from 'react-native';
+import React, { Component } from 'react';
+import Clipboard from '@react-native-community/clipboard';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+import { Title, Colors, Body, Caption } from '../../components';
+
+/**
+ * @prop {string} identifier
+ * @prop {string} teamName
+ */
+export class TeamTitle extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            opacityAnimation: new Animated.Value(0)
+        };
+    }
+
+    /**
+     * copy team unique identifier to Clipboard
+     */
+    copyIdentifier = async () => {
+        Clipboard.setString(this.props.identifier);
+        this.opacityAnmiation();
+    };
+
+    /**
+     * opactity animations for Copied message
+     */
+    opacityAnmiation = async () => {
+        Animated.timing(this.state.opacityAnimation, {
+            toValue: 1,
+            duration: 500,
+            useNativeDriver: true,
+            easing: Easing.elastic(1)
+        }).start(this.returnOpacityAnmiation);
+    };
+
+    returnOpacityAnmiation = async () => {
+        Animated.timing(this.state.opacityAnimation, {
+            toValue: 0,
+            duration: 800,
+            useNativeDriver: true,
+            easing: Easing.elastic(1)
+        }).start();
+    };
+
+    render() {
+        const opacityStyle = {
+            opacity: this.state.opacityAnimation
+        };
+
+        const { identifier, teamName } = this.props;
+        return (
+            <View>
+                <Pressable
+                    onPress={this.copyIdentifier}
+                    style={styles.titleContainer}>
+                    <Title>{teamName}</Title>
+                    <View style={{ flexDirection: 'row' }}>
+                        <Body color="accent" style={{ marginRight: 10 }}>
+                            {identifier}
+                        </Body>
+                        <Icon
+                            name="ios-copy-outline"
+                            color={Colors.accent}
+                            size={18}
+                        />
+                    </View>
+                </Pressable>
+                {/* Copied message */}
+                <Animated.View style={opacityStyle}>
+                    <Caption color="accent" style={{ textAlign: 'center' }}>
+                        Copied
+                    </Caption>
+                </Animated.View>
+            </View>
+        );
+    }
+}
+
+export default TeamTitle;
+
+const styles = StyleSheet.create({
+    titleContainer: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: 20
+    }
+});

--- a/screens/team/teamComponents/index.js
+++ b/screens/team/teamComponents/index.js
@@ -5,3 +5,4 @@ export { default as JoinTeamForm } from './JoinTeamForm';
 export { default as CreateTeamForm } from './CreateTeamForm';
 export { default as MemberCard } from './MemberCard';
 export { default as TeamListCard } from './TeamListCard';
+export { default as TeamTitle } from './TeamTitle';


### PR DESCRIPTION
- added team name and copy identifier fn on team leaderboard screen

**Trello**
[In the Team leaderboard, show the Team name + copy key icon again](https://trello.com/c/ZhmALTF0)



<img width="391" alt="Screenshot 2022-04-21 at 12 15 19 AM" src="https://user-images.githubusercontent.com/26044934/164301128-9635f018-cde4-4014-be3b-17d7848185ee.png">
