### PR TITLE
feat: open tagging container initially on image open

### DIFF
--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -42,7 +42,7 @@ class AddTags extends Component {
             categoryAnimation: new Animated.Value(100),
             sheetAnimation: new Animated.Value(0),
             opacityAnimation: new Animated.Value(1),
-            isCategoriesVisible: false,
+            isCategoriesVisible: true,
             isKeyboardOpen: false,
             keyboardHeight: 0,
             isOverlayDisplayed: false,
@@ -75,6 +75,9 @@ class AddTags extends Component {
                 this.startAnimation(-400);
             }
         );
+
+        // initially open tagging contaner
+        this.openTaggingContainer();
     }
 
     /**
@@ -219,6 +222,17 @@ class AddTags extends Component {
             useNativeDriver: true,
             easing: Easing.elastic(1)
         }).start();
+    };
+
+    /**
+     * fn to open tagging containers with animation
+     */
+
+    openTaggingContainer = () => {
+        this.startAnimation(-400);
+        this.setState({
+            isCategoriesVisible: true
+        });
     };
 
     /** function for deleting image
@@ -413,16 +427,7 @@ class AddTags extends Component {
                                     this.props.images[this.props.swiperIndex]
                                         ?.picked_up
                                 }
-                                openTagSheet={() => {
-                                    if (this.state.isCategoriesVisible) {
-                                        this.returnAnimation();
-                                    } else {
-                                        this.startAnimation(-400);
-                                        this.setState({
-                                            isCategoriesVisible: true
-                                        });
-                                    }
-                                }}
+                                openTagSheet={this.openTaggingContainer}
                                 toggleOverlay={() => {
                                     this.setState(previousState => ({
                                         isOverlayDisplayed: !previousState.isOverlayDisplayed


### PR DESCRIPTION
- on opening image tagging section is shown right away, and on tap meta screen is shown.

**Trello**
[When we select an image for tagging, start tagging right away instead of the metadata screen. Tap image once to switch to metadata page](https://trello.com/c/30pzCCb1)



https://user-images.githubusercontent.com/26044934/164746268-986b9322-d4f8-41e5-864d-8c4b57ddd432.mov

