### PR TITLE
feat: press and hold image to hide all tagging containers

### DIFF
--- a/screens/addTag/AddTags.js
+++ b/screens/addTag/AddTags.js
@@ -175,17 +175,20 @@ class AddTags extends Component {
     /**
      * Fn for close animation
      * happen on backdrop click
+     * @param pressType --> "LONG" | "REGULAR"
+     * if pressType === LONG hide categories and tag section but dont show Meta details
      */
-    returnAnimation = () => {
+    returnAnimation = (pressType = 'REGULAR') => {
         Animated.timing(this.state.categoryAnimation, {
             toValue: -this.categoryContainerPosition,
             duration: 500,
             useNativeDriver: true,
             easing: Easing.elastic(1)
         }).start(() => {
-            this.setState({
-                isCategoriesVisible: false
-            });
+            pressType === 'REGULAR' &&
+                this.setState({
+                    isCategoriesVisible: false
+                });
         });
         Animated.timing(this.state.sheetAnimation, {
             toValue: 100,
@@ -573,9 +576,14 @@ class AddTags extends Component {
                     photoSelected={image}
                     swiperIndex={this.props.swiperIndex}
                     navigation={this.props.navigation}
-                    toggleFn={() => {
+                    // hide all tagging containers
+                    onLongPressStart={() => this.returnAnimation('LONG')}
+                    // show all tagging containers
+                    onLongPressEnd={() => this.startAnimation()}
+                    // hide tagging containers and show meta containers
+                    onImageTap={() => {
                         if (this.state.isCategoriesVisible) {
-                            this.returnAnimation();
+                            this.returnAnimation('REGULAR');
                         }
                     }}
                 />

--- a/screens/addTag/addTagComponents/LitterImage.js
+++ b/screens/addTag/addTagComponents/LitterImage.js
@@ -33,7 +33,8 @@ class LitterImage extends PureComponent {
         super(props);
 
         this.state = {
-            imageLoaded: false
+            imageLoaded: false,
+            isLongPress: false
         };
     }
 
@@ -82,8 +83,21 @@ class LitterImage extends PureComponent {
                     onGestureEvent={this.onPinchGestureEvent}
                     onHandlerStateChange={this.onPinchHandlerStateChange}>
                     <AnimatedPressable
+                        // if image is taped/ pressed once hide containers and show meta containers
                         onPress={() => {
-                            this.props.toggleFn();
+                            this.setState({ isLongPress: false });
+                            this.props.onImageTap();
+                        }}
+                        // if image is long pressed and  hold hide all containers
+                        onLongPress={() => {
+                            this.setState({ isLongPress: true });
+                            this.props.onLongPressStart();
+                        }}
+                        // if image is long pressed bring back all containers on pressOut
+                        // if image is not long pressed don't do anything and let onPress handle it
+                        onPressOut={() => {
+                            this.state.isLongPress &&
+                                this.props.onLongPressEnd();
                         }}
                         style={{ backgroundColor: 'black' }}>
                         <Animated.Image


### PR DESCRIPTION
- Press and hold image to hide all the tagging containers

**Trello**
[When we press and hold the image, it would be nice to hide all containers](https://trello.com/c/tS006tMo)


https://user-images.githubusercontent.com/26044934/165237818-69ccf2cf-a2e8-491b-9682-ddf2311f7490.mov

