### PR TITLE
feat: sentry image upload logs

### DIFF
--- a/actions/auth_actions.js
+++ b/actions/auth_actions.js
@@ -15,6 +15,7 @@ import {
     URL
 } from './types';
 import axios from 'axios';
+import * as Sentry from '@sentry/react-native';
 
 export const changeLang = lang => {
     return {
@@ -359,6 +360,10 @@ export const fetchUser = token => {
         }
         if (response && response.status === 200 && response.data) {
             const userObj = response.data;
+            // Adding context -- user to Sentry
+            // will be able to identify the user who faced the errors.
+            Sentry.setUser({ email: userObj?.email, id: userObj?.id });
+
             dispatch({
                 type: USER_FOUND,
                 payload: { userObj, token }

--- a/actions/images_action.js
+++ b/actions/images_action.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import * as Sentry from '@sentry/react-native';
 import {
     ADD_IMAGES,
     ADD_TAG_TO_IMAGE,
@@ -252,9 +253,15 @@ export const uploadImage = (token, image, imageId) => {
             });
         } catch (error) {
             if (error.response) {
-                console.log(
-                    'ERROR: shared_actions.upload_photo',
-                    JSON.stringify(error?.response?.data, null, 2)
+                // log error in sentry
+                Sentry.captureException(
+                    JSON.stringify(error?.response?.data, null, 2),
+                    {
+                        level: 'error',
+                        tags: {
+                            section: 'image_upload'
+                        }
+                    }
                 );
             } else {
                 // Other errors -- NETWORK ERROR
@@ -265,7 +272,6 @@ export const uploadImage = (token, image, imageId) => {
                 success: false
             };
         }
-        console.log('Response: shared_actions.uploadPhoto', response?.data);
 
         if (response && response.data?.success) {
             dispatch({


### PR DESCRIPTION
- Adding user context to sentry logs. Helpful is identifying the user who faced the issue.
- Logging image upload errors to sentry


We will be able to see image upload error logs API like this in sentry.

<img width="874" alt="Screenshot 2022-05-13 at 1 17 26 PM" src="https://user-images.githubusercontent.com/26044934/168236568-272e7006-c139-49b6-a448-b5fbec889843.png">


**Trello**
[Improve logging](https://trello.com/c/6lBFpiCb)