### PR TITLE
fix: use xp_redis instead of xp

### DIFF
--- a/reducers/auth_reducer.js
+++ b/reducers/auth_reducer.js
@@ -144,11 +144,11 @@ export default function(state = INITIAL_STATE, action) {
             case USER_FOUND:
                 let user = action.payload.userObj;
 
-                const level = XPLEVEL.findIndex(xp => xp > user.xp);
-                const xpRequired = XPLEVEL[level] - user.xp;
+                const level = XPLEVEL.findIndex(xp => xp > user.xp_redis);
+                const xpRequired = XPLEVEL[level] - user.xp_redis;
                 const previousTarget = level > 0 ? XPLEVEL[level - 1] : 0;
                 const targetPercentage =
-                    ((user.xp - previousTarget) /
+                    ((user.xp_redis - previousTarget) /
                         (XPLEVEL[level] - previousTarget)) *
                     100;
 

--- a/screens/userStats/UserStatsScreen.js
+++ b/screens/userStats/UserStatsScreen.js
@@ -16,7 +16,6 @@ import { ProgressCircleCard } from './userComponents';
 class UserStatsScreen extends Component {
     constructor(props) {
         super(props);
-
         this.state = {
             xpStart: 0,
             positionStart: 0,
@@ -68,7 +67,7 @@ class UserStatsScreen extends Component {
         await this.props.fetchUser(this.props.token);
         const user = this.props.user;
         const statsObj = {
-            xp: user?.xp,
+            xp: user?.xp_redis,
             position: user?.position,
             totalImages: user?.total_images || 0,
             totalTags: user?.totalTags,
@@ -88,7 +87,7 @@ class UserStatsScreen extends Component {
 
         const statsData = [
             {
-                value: user?.xp || this.state.xpStart,
+                value: user?.xp_redis || this.state.xpStart,
                 startValue: this.state.xpStart,
                 title: `${lang}.user.XP`,
                 icon: 'ios-medal-outline',
@@ -202,7 +201,7 @@ const styles = StyleSheet.create({
     }
 });
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
     return {
         lang: state.auth.lang,
         token: state.auth.token,
@@ -210,4 +209,7 @@ const mapStateToProps = (state) => {
     };
 };
 
-export default connect(mapStateToProps, actions)(UserStatsScreen);
+export default connect(
+    mapStateToProps,
+    actions
+)(UserStatsScreen);


### PR DESCRIPTION
- PR to user user.xp_redis instead of user.xp for showing XP in app.

**Trello**
[Drop user.xp and use redis values for XP](https://trello.com/c/jN1umVCR)