### PR TITLE
feat: animate image on select in gallery

### DIFF
--- a/screens/gallery/GalleryScreen.js
+++ b/screens/gallery/GalleryScreen.js
@@ -5,7 +5,6 @@ import {
     Pressable,
     FlatList,
     Dimensions,
-    Image,
     SafeAreaView,
     ActivityIndicator
 } from 'react-native';
@@ -18,6 +17,7 @@ import * as actions from '../../actions';
 import { Header, SubTitle, Body, Caption, Colors } from '../components';
 import { isGeotagged } from '../../utils/isGeotagged';
 import { checkCameraRollPermission } from '../../utils/permissions';
+import AnimatedImage from './galleryComponents/AnimatedImage';
 
 const { width } = Dimensions.get('window');
 
@@ -224,60 +224,15 @@ class GalleryScreen extends Component {
 
                         const isImageGeotagged = isGeotagged(image);
                         return (
-                            <Pressable
+                            <AnimatedImage
                                 key={image.uri}
                                 onPress={() =>
                                     isImageGeotagged && this.selectImage(image)
-                                }>
-                                <Image
-                                    source={{ uri: image.uri }}
-                                    style={{
-                                        width: width / 3 - 2,
-                                        height: width / 3 - 2,
-                                        margin: 1
-                                    }}
-                                />
-                                {selected && (
-                                    <View
-                                        style={{
-                                            position: 'absolute',
-                                            width: 24,
-                                            height: 24,
-                                            backgroundColor: '#0984e3',
-                                            right: 10,
-                                            bottom: 10,
-                                            borderRadius: 100,
-                                            justifyContent: 'center',
-                                            alignItems: 'center'
-                                        }}>
-                                        <Icon
-                                            name="ios-checkmark-outline"
-                                            size={20}
-                                            color="white"
-                                        />
-                                    </View>
-                                )}
-                                {isImageGeotagged && (
-                                    <View
-                                        style={{
-                                            position: 'absolute',
-                                            width: 24,
-                                            height: 24,
-                                            backgroundColor: '#0984e3',
-                                            right: 10,
-                                            top: 10,
-                                            borderRadius: 100,
-                                            justifyContent: 'center',
-                                            alignItems: 'center'
-                                        }}>
-                                        <Icon
-                                            name="ios-location-outline"
-                                            size={16}
-                                            color="white"
-                                        />
-                                    </View>
-                                )}
-                            </Pressable>
+                                }
+                                image={image}
+                                isImageGeotagged={isImageGeotagged}
+                                selected={selected}
+                            />
                         );
                     })}
                 </View>

--- a/screens/gallery/galleryComponents/AnimatedImage.js
+++ b/screens/gallery/galleryComponents/AnimatedImage.js
@@ -1,133 +1,72 @@
-import {
-    View,
-    Pressable,
-    Animated,
-    Dimensions,
-    Easing,
-    StyleSheet
-} from 'react-native';
-import React, { Component } from 'react';
+import { View, Pressable, Image, Dimensions, StyleSheet } from 'react-native';
+import React from 'react';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { Colors } from '../../components';
 
 const { width } = Dimensions.get('window');
 
-class AnimatedImage extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            borderRadiusAnimation: new Animated.Value(0),
-            sizeAnimation: new Animated.Value(1)
-        };
-    }
-
-    /**
-     * animate borderRadius to 20
-     * animate scale to 80% / 0.8
-     */
-    selectImageAnimation() {
-        Animated.timing(this.state.borderRadiusAnimation, {
-            toValue: 20,
-            duration: 300,
-            useNativeDriver: true,
-            easing: Easing.elastic(1)
-        }).start();
-        Animated.timing(this.state.sizeAnimation, {
-            toValue: 0.8,
-            duration: 300,
-            useNativeDriver: true
-        }).start();
-    }
-    unselectImageAnimation() {
-        Animated.timing(this.state.borderRadiusAnimation, {
-            toValue: 0,
-            duration: 800,
-            useNativeDriver: true,
-            easing: Easing.elastic(1)
-        }).start();
-        Animated.timing(this.state.sizeAnimation, {
-            toValue: 1,
-            duration: 300,
-            useNativeDriver: true
-        }).start();
-    }
-
+const AnimatedImage = ({ image, isImageGeotagged, selected, onPress }) => {
     /**
      * only press image if its geoTagged
      *
      * run animation and call fn this.props.onPress() which will mark the image as selected
      */
     onImagePress = () => {
-        if (this.props.isImageGeotagged) {
-            this.props.selected
-                ? this.unselectImageAnimation()
-                : this.selectImageAnimation();
-            this.props.onPress();
+        if (isImageGeotagged) {
+            onPress();
         }
     };
 
-    render() {
-        const { image, isImageGeotagged, selected } = this.props;
-        return (
-            <Pressable key={image.uri} onPress={this.onImagePress}>
-                <View
-                    style={{
-                        width: width / 3 - 2,
-                        height: width / 3 - 2,
-                        margin: 1,
-                        backgroundColor: Colors.accentLight
-                    }}>
-                    <Animated.Image
-                        source={{ uri: image.uri }}
+    return (
+        <Pressable key={image.uri} onPress={this.onImagePress}>
+            <View style={styles.grid}>
+                <Image
+                    source={{ uri: image.uri }}
+                    style={[styles.imageStyle]}
+                />
+            </View>
+
+            {selected && (
+                <>
+                    {/* overlay */}
+                    <View
                         style={[
+                            styles.grid,
                             {
-                                width: '100%',
-                                height: '100%',
-                                borderRadius: this.state.borderRadiusAnimation,
-                                transform: [
-                                    {
-                                        scale: this.state.sizeAnimation
-                                    }
-                                ]
+                                position: 'absolute',
+                                backgroundColor: Colors.muted,
+                                opacity: 0.3
                             }
                         ]}
                     />
-                </View>
-
-                {selected && (
-                    <View
-                        style={[
-                            styles.selectedIcon,
-                            selected && styles.iconBorderStyle
-                        ]}>
+                    {/* Selected check mark icon */}
+                    <View style={[styles.selectedIcon, styles.iconBorderStyle]}>
                         <Icon
                             name="ios-checkmark-outline"
                             size={20}
                             color="white"
                         />
                     </View>
-                )}
-                {isImageGeotagged && (
-                    <View
-                        style={[
-                            styles.geotaggedIcon,
-                            selected && styles.iconBorderStyle
-                        ]}>
-                        <Icon
-                            name="ios-location-outline"
-                            size={16}
-                            color="white"
-                        />
-                    </View>
-                )}
-            </Pressable>
-        );
-    }
-}
+                </>
+            )}
+
+            {isImageGeotagged && (
+                <View style={[styles.geotaggedIcon, styles.iconBorderStyle]}>
+                    <Icon name="ios-location-outline" size={16} color="white" />
+                </View>
+            )}
+        </Pressable>
+    );
+};
 
 export default AnimatedImage;
 
 const styles = StyleSheet.create({
+    grid: {
+        width: width / 3 - 2,
+        height: width / 3 - 2,
+        margin: 1
+    },
     geotaggedIcon: {
         position: 'absolute',
         width: 24,
@@ -144,8 +83,8 @@ const styles = StyleSheet.create({
         width: 24,
         height: 24,
         backgroundColor: '#0984e3',
-        left: 5,
-        top: 5,
+        right: 5,
+        bottom: 5,
         borderRadius: 100,
         justifyContent: 'center',
         alignItems: 'center'
@@ -153,5 +92,9 @@ const styles = StyleSheet.create({
     iconBorderStyle: {
         borderWidth: 1,
         borderColor: Colors.accentLight
+    },
+    imageStyle: {
+        width: '100%',
+        height: '100%'
     }
 });

--- a/screens/gallery/galleryComponents/AnimatedImage.js
+++ b/screens/gallery/galleryComponents/AnimatedImage.js
@@ -1,0 +1,157 @@
+import {
+    View,
+    Pressable,
+    Animated,
+    Dimensions,
+    Easing,
+    StyleSheet
+} from 'react-native';
+import React, { Component } from 'react';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { Colors } from '../../components';
+
+const { width } = Dimensions.get('window');
+
+class AnimatedImage extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            borderRadiusAnimation: new Animated.Value(0),
+            sizeAnimation: new Animated.Value(1)
+        };
+    }
+
+    /**
+     * animate borderRadius to 20
+     * animate scale to 80% / 0.8
+     */
+    selectImageAnimation() {
+        Animated.timing(this.state.borderRadiusAnimation, {
+            toValue: 20,
+            duration: 300,
+            useNativeDriver: true,
+            easing: Easing.elastic(1)
+        }).start();
+        Animated.timing(this.state.sizeAnimation, {
+            toValue: 0.8,
+            duration: 300,
+            useNativeDriver: true
+        }).start();
+    }
+    unselectImageAnimation() {
+        Animated.timing(this.state.borderRadiusAnimation, {
+            toValue: 0,
+            duration: 800,
+            useNativeDriver: true,
+            easing: Easing.elastic(1)
+        }).start();
+        Animated.timing(this.state.sizeAnimation, {
+            toValue: 1,
+            duration: 300,
+            useNativeDriver: true
+        }).start();
+    }
+
+    /**
+     * only press image if its geoTagged
+     *
+     * run animation and call fn this.props.onPress() which will mark the image as selected
+     */
+    onImagePress = () => {
+        if (this.props.isImageGeotagged) {
+            this.props.selected
+                ? this.unselectImageAnimation()
+                : this.selectImageAnimation();
+            this.props.onPress();
+        }
+    };
+
+    render() {
+        const { image, isImageGeotagged, selected } = this.props;
+        return (
+            <Pressable key={image.uri} onPress={this.onImagePress}>
+                <View
+                    style={{
+                        width: width / 3 - 2,
+                        height: width / 3 - 2,
+                        margin: 1,
+                        backgroundColor: Colors.accentLight
+                    }}>
+                    <Animated.Image
+                        source={{ uri: image.uri }}
+                        style={[
+                            {
+                                width: '100%',
+                                height: '100%',
+                                borderRadius: this.state.borderRadiusAnimation,
+                                transform: [
+                                    {
+                                        scale: this.state.sizeAnimation
+                                    }
+                                ]
+                            }
+                        ]}
+                    />
+                </View>
+
+                {selected && (
+                    <View
+                        style={[
+                            styles.selectedIcon,
+                            selected && styles.iconBorderStyle
+                        ]}>
+                        <Icon
+                            name="ios-checkmark-outline"
+                            size={20}
+                            color="white"
+                        />
+                    </View>
+                )}
+                {isImageGeotagged && (
+                    <View
+                        style={[
+                            styles.geotaggedIcon,
+                            selected && styles.iconBorderStyle
+                        ]}>
+                        <Icon
+                            name="ios-location-outline"
+                            size={16}
+                            color="white"
+                        />
+                    </View>
+                )}
+            </Pressable>
+        );
+    }
+}
+
+export default AnimatedImage;
+
+const styles = StyleSheet.create({
+    geotaggedIcon: {
+        position: 'absolute',
+        width: 24,
+        height: 24,
+        backgroundColor: '#0984e3',
+        right: 5,
+        top: 5,
+        borderRadius: 100,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    selectedIcon: {
+        position: 'absolute',
+        width: 24,
+        height: 24,
+        backgroundColor: '#0984e3',
+        left: 5,
+        top: 5,
+        borderRadius: 100,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    iconBorderStyle: {
+        borderWidth: 1,
+        borderColor: Colors.accentLight
+    }
+});


### PR DESCRIPTION
PR to add animation when selecting image in gallery screen, and solves the issue mentioned by users about hard to identify which image is selected.

**Trello**
[Gallery image select  geolocation and selected icons are confusing for some users.](https://trello.com/c/hhnNs9ne)

https://user-images.githubusercontent.com/26044934/172699155-7f58773b-2724-44aa-8def-4563569d4957.mov

